### PR TITLE
Fix/docker image

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -48,7 +48,7 @@ services:
       - db-server
 
   db-server:
-    image: postgres
+    image: postgres:16
     restart: unless-stopped
     volumes:
       - ./data/db-server-data:/var/lib/postgresql/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - db-server
 
   db-server:
-    image: postgres
+    image: postgres:16
     expose:
       - "5432"
     ports:


### PR DESCRIPTION
Added an explicit Postgres version (postgres:16) to the Docker Compose file to prevent unexpected mount configuration errors that can occur when the latest image tag pulls a newer major version (configurations have been changed from version 18+).