### PR TITLE
Feature: add option to exclude failed interleavings in dashboard

### DIFF
--- a/web/app/dashboard.py
+++ b/web/app/dashboard.py
@@ -6,7 +6,7 @@ from .models import Feedback, Result, Session, System, User, Role
 
 class Dashboard:
 
-    def __init__(self, user_id, system_id=None, site_id=None, start_datetime=None, end_datetime=None):
+    def __init__(self, user_id, system_id=None, site_id=None, start_datetime=None, end_datetime=None, exclude_failed_interleavings=False):
 
         user_role_id = db.session.get(User, user_id).role_id
          
@@ -156,6 +156,11 @@ class Dashboard:
             for i, f in enumerate(self.feedbacks):
                 clicks = f.clicks
                 
+                click_types = set([c['type'] for c in clicks.values()])
+
+                if exclude_failed_interleavings and ('EXP' not in click_types or 'BASE' not in click_types):
+                    continue
+
                 # Skip if clicks is None or not a dictionary
                 if not clicks or not isinstance(clicks, dict):
                     continue

--- a/web/app/main/forms.py
+++ b/web/app/main/forms.py
@@ -10,7 +10,8 @@ from wtforms import (
     SubmitField,
     URLField,
     ValidationError,
-    DateField
+    DateField,
+    BooleanField
 )
 from wtforms.fields import SelectField
 from wtforms.validators import URL, DataRequired, Email, EqualTo, Length, Regexp, Optional
@@ -23,6 +24,7 @@ class Dropdown(FlaskForm):
     system = SelectField("", choices=[])
     start_date = DateField("From", format="%Y-%m-%d", validators=[Optional()])
     end_date = DateField("To", format="%Y-%m-%d", validators=[Optional()])
+    exclude_failed_interleavings = BooleanField("Exclude failed interleavings", default=True)
     submit = SubmitField("Show results")
 
 

--- a/web/app/main/views.py
+++ b/web/app/main/views.py
@@ -83,12 +83,13 @@ def dashboard():
         system_id = request.form.get("system")
         date_from_raw = request.form.get("start_date")
         date_to_raw = request.form.get("end_date")
+        exclude_failed_interleavings = request.form.get("exclude_failed_interleavings") == "y"
 
         date_from = datetime.strptime(date_from_raw, "%Y-%m-%d").date() if date_from_raw else None
         date_to = datetime.strptime(date_to_raw, "%Y-%m-%d").date() if date_to_raw else None
 
         site_id = db.session.query(System).filter_by(id=system_id).first().site
-        dashboard = Dashboard(current_user.id, system_id, site_id, date_from, date_to)
+        dashboard = Dashboard(current_user.id, system_id, site_id, date_from, date_to, exclude_failed_interleavings)
     else:
         dashboard = Dashboard(current_user.id)
 

--- a/web/app/templates/base.html
+++ b/web/app/templates/base.html
@@ -17,6 +17,77 @@
             color: #ffffff;
             background-color: #201C2D;
         }
+
+        .switch {
+        position: relative;
+        display: inline-block;
+        width: 46px;
+        height: 24px;
+        }
+
+        .switch input {
+        opacity: 0;
+        width: 0;
+        height: 0;
+        }
+
+        .slider {
+        position: absolute;
+        cursor: pointer;
+        top: 0; left: 0; right: 0; bottom: 0;
+        background-color: #ccc;
+        transition: .3s;
+        border-radius: 24px;
+        }
+
+        .slider:before {
+        position: absolute;
+        content: "";
+        height: 18px; width: 18px;
+        left: 3px; bottom: 3px;
+        background-color: white;
+        transition: .3s;
+        border-radius: 50%;
+        }
+
+        input:checked + .slider {
+        background-color: #28a745;
+        }
+
+        input:checked + .slider:before {
+        transform: translateX(22px);
+        }
+
+        .switch-box {
+            border: 1px solid #ccc;
+            border-radius: 5px;
+            padding: 4px 12px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 10px;
+            background-color: #f9f9f9; /* optional */
+        }
+
+        /* Optional hover effect */
+        .switch-box:hover {
+            border-color: #999;
+        }
+
+        /* Label styling */
+        .switch-label {
+            font-weight: bold;
+        }
+
+        .form-label {
+            font-weight: 600;
+            margin-bottom: 4px;
+        }
+
+        .form-control {
+            height: 38px;
+            width: 50%;
+        }
     </style>
 {% endblock %}
 

--- a/web/app/templates/base.html
+++ b/web/app/templates/base.html
@@ -67,6 +67,7 @@
             justify-content: center;
             gap: 10px;
             background-color: #f9f9f9; /* optional */
+            box-shadow: #201C2D 0px 5px 0px;
         }
 
         /* Optional hover effect */
@@ -79,14 +80,18 @@
             font-weight: bold;
         }
 
-        .form-label {
+        .form-label-dashboard {
             font-weight: 600;
             margin-bottom: 4px;
         }
 
-        .form-control {
+        .form-control-dashboard {
             height: 38px;
             width: 50%;
+            border: 1px solid #ccc;
+            border-radius: 5px;
+            padding: 4px 12px;
+            box-shadow: #201C2D 0px 5px 0px;
         }
     </style>
 {% endblock %}

--- a/web/app/templates/dashboard.html
+++ b/web/app/templates/dashboard.html
@@ -15,21 +15,49 @@
 
         <div style=margin-bottom:80px;>
             <form method="POST" action="/dashboard">
-                <div class="col-md-4">
-                    {{ wtf.form_field(form.system, form_type="horizontal") }}
+                <div class="row">
+                    <div class="col-md-6">
+                        <div style="width: 300px; margin-left: auto;">   
+                            {{ form.system(class="form-control", style="width: 300px;") }}
+                        </div>
+                    </div>
+                    
+                    <div class="col-md-3 text-center">
+                        <div class="switch-box" style="width: 300px; margin-right: auto;"> 
+                            <span title="Filters out comparisons where only one system returned results">
+                                <strong>Exclude failed interleavings</strong>
+                            </span>
+                            <label class="switch">
+                                {{ form.exclude_failed_interleavings(style="width: 300px;") }}
+                                <span class="slider"></span>
+                            </label>
+                        </div>
+                        
+                    </div>
+                    <div class="col-md-3">
+                        <div style="width: 100px; margin-left: auto; margin-right: auto;">
+                            {{ form.submit(class="btn btn-primary form-control", style="width: 120px;") }}
+                        </div>
+                    </div>
                 </div>
-                <div class="col-md-3">
-                    {{ wtf.form_field(form.start_date, form_type="horizontal") }}
+
+                <div class="row" style="margin-top: 35px;">
+                    <div class="col-md-6">
+                        <div style="width: 300px; margin-left: auto;">
+                            <label class="form-label">Start Date</label>
+                            {{ form.start_date(class="form-control", style="width: 300px;") }}
+                        </div>
+                    </div>
+                    <div class="col-md-6">
+                        <div style="width: 300px; margin-right: auto;">
+                            <label class="form-label">End Date</label>
+                            {{ form.end_date(class="form-control", style="width: 300px;") }}
+                        </div>
+                    </div>
                 </div>
-                <div class="col-md-3">
-                    {{ wtf.form_field(form.end_date, form_type="horizontal") }}
-                </div>
-                <div class="col-md-2">
-                    {{ wtf.form_field(form.submit) }}
-                </div>
+                
             </form>
         </div>
-
 
         <div class="row row-no-gutters">
 

--- a/web/app/templates/dashboard.html
+++ b/web/app/templates/dashboard.html
@@ -18,7 +18,7 @@
                 <div class="row">
                     <div class="col-md-6">
                         <div style="width: 300px; margin-left: auto;">   
-                            {{ form.system(class="form-control", style="width: 300px;") }}
+                            {{ form.system(class="form-control-dashboard", style="width: 300px;") }}
                         </div>
                     </div>
                     
@@ -36,7 +36,7 @@
                     </div>
                     <div class="col-md-3">
                         <div style="width: 100px; margin-left: auto; margin-right: auto;">
-                            {{ form.submit(class="btn btn-primary form-control", style="width: 120px;") }}
+                            {{ form.submit(class="btn btn-primary form-control-dashboard", style="width: 120px; box-shadow:none") }}
                         </div>
                     </div>
                 </div>
@@ -44,14 +44,14 @@
                 <div class="row" style="margin-top: 35px;">
                     <div class="col-md-6">
                         <div style="width: 300px; margin-left: auto;">
-                            <label class="form-label">Start Date</label>
-                            {{ form.start_date(class="form-control", style="width: 300px;") }}
+                            <label class="form-label-dashboard">Start Date</label>
+                            {{ form.start_date(class="form-control-dashboard", style="width: 300px;") }}
                         </div>
                     </div>
                     <div class="col-md-6">
                         <div style="width: 300px; margin-right: auto;">
-                            <label class="form-label">End Date</label>
-                            {{ form.end_date(class="form-control", style="width: 300px;") }}
+                            <label class="form-label-dashboard">End Date</label>
+                            {{ form.end_date(class="form-control-dashboard", style="width: 300px;") }}
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
This PR introduces an optional filter to exclude failed interleaving cases from the evaluation results in the STELLA dashboard.

In some situations, one of the compared systems does not return any results (e.g., due to timeouts). The resulting interleaved list then contains documents from only one system, which leads to a biased outcome where that system is counted as a “win” by default.

Changes
- Added a toggle option: “Exclude failed interleavings”
- When enabled:
  ->Interleavings where only one system contributed results are filtered out
  ->These cases are excluded from evaluation metrics and tables
- Default behavior: enabled (to avoid biased evaluation)